### PR TITLE
Automated daily refresh of README.md, to trigger rebuild of images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,8 +5,6 @@ on:
     branches:
       - master
   pull_request:
-  schedule:
-    - cron: "0 4 * * *"
 
 concurrency:
   group: ${{ github.ref }}

--- a/.github/workflows/refresh.yaml
+++ b/.github/workflows/refresh.yaml
@@ -1,0 +1,29 @@
+name: refresh
+
+on:
+  schedule:
+    # Every day at 04:00 UTC
+    - cron: "0 6 * * *"
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: Update date in README.md
+        run: |
+          sed -i 's/last update:.*/last update: '"$(date +%Y-%m-%d)"')\./' README.md
+
+      - name: Commit file
+        run: |
+          git config --local user.email "<oca-git-bot@odoo-community.org>"
+          git config --local user.name "OCA-git-bot"
+          git add ./README.md
+          git commit -m "Automated refresh on $(date +%Y-%m-%d)"
+
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ CI on these images, be aware that, while we will not break things without
 reason, we will prioritize ease of maintenance for OCA over backward
 compatibility. ⚠️
 
-These images provide the following guarantees:
+They are automatically rebuilt at least once per day,
+to include the latest changes from Odoo (last update: 2024-09-08).
+
+They provide the following guarantees:
 
 - Odoo runtime dependencies are installed (`wkhtmltopdf`, `lessc`, etc).
 - Odoo source code is in `/opt/odoo`.


### PR DESCRIPTION
- The scheduled ci workflow was disabled by Github whenever there hadn't been activity in the repository for at least 60 days.
- So instead we now rely on another workflow that will automatically refresh the README.md daily and push it to master branch
- ...hence triggering the ci workflow daily